### PR TITLE
feat: TODO削除機能を実装

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -116,3 +116,28 @@ nav {
   height: 18px;
   cursor: pointer;
 }
+
+.delete-button {
+  margin-left: auto;
+  padding: 6px 12px;
+  background-color: #f44336;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background-color 0.3s;
+}
+
+.delete-button:hover {
+  background-color: #d32f2f;
+}
+
+#todo-list li {
+  display: flex;
+  align-items: center;
+}
+
+#todo-list label {
+  flex: 1;
+}

--- a/src/todoApp.js
+++ b/src/todoApp.js
@@ -50,7 +50,16 @@ function createTodoApp(container) {
       label.appendChild(checkbox);
       label.appendChild(document.createTextNode(' ' + todo.text));
       
+      const deleteButton = document.createElement('button');
+      deleteButton.className = 'delete-button';
+      deleteButton.textContent = '削除';
+      deleteButton.addEventListener('click', () => {
+        todos = todos.filter(t => t.id !== todo.id);
+        render();
+      });
+      
       li.appendChild(label);
+      li.appendChild(deleteButton);
       todoList.appendChild(li);
     });
   }

--- a/src/todoApp.test.js
+++ b/src/todoApp.test.js
@@ -195,4 +195,47 @@ describe('TODO App Functionality', () => {
       expect(checkbox).toBeInTheDocument();
     });
   });
+
+  test('should delete todo when delete button is clicked', () => {
+    const form = container.querySelector('#todo-form');
+    const input = form.querySelector('input[type="text"]');
+    const todoList = container.querySelector('#todo-list');
+
+    // TODOを3つ追加
+    ['TODO 1', 'TODO 2', 'TODO 3'].forEach(text => {
+      input.value = text;
+      form.dispatchEvent(new Event('submit', { bubbles: true }));
+    });
+
+    expect(todoList.children).toHaveLength(3);
+
+    // 2番目のTODOを削除
+    const deleteButton = todoList.children[1].querySelector('.delete-button');
+    deleteButton.click();
+
+    // TODOが2つになっていること
+    expect(todoList.children).toHaveLength(2);
+    expect(todoList.children[0].textContent).toContain('TODO 1');
+    expect(todoList.children[1].textContent).toContain('TODO 3');
+  });
+
+  test('should display delete button for each todo item', () => {
+    const form = container.querySelector('#todo-form');
+    const input = form.querySelector('input[type="text"]');
+    const todoList = container.querySelector('#todo-list');
+
+    // 複数のTODOを追加
+    ['TODO 1', 'TODO 2'].forEach(text => {
+      input.value = text;
+      form.dispatchEvent(new Event('submit', { bubbles: true }));
+    });
+
+    // 各TODOアイテムに削除ボタンがあること
+    const todoItems = todoList.querySelectorAll('li');
+    todoItems.forEach(item => {
+      const deleteButton = item.querySelector('.delete-button');
+      expect(deleteButton).toBeInTheDocument();
+      expect(deleteButton.textContent).toBe('削除');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- 各TODOアイテムに削除ボタンを追加しました
- IDベースの削除処理により、フィルター機能追加時も安全に動作します
- 赤い削除ボタンでユーザーに分かりやすいUIを提供

## Linear Issue
- [FORTUNE-20: TODO削除機能を実装](https://linear.app/test0701/issue/FORTUNE-20)

## Changes
- ✅ 削除ボタンの表示テストを追加
- ✅ 削除機能の動作テストを追加
- ✅ IDベースの削除処理を実装
- ✅ 削除ボタンのスタイリング

## Test plan
- [x] `npm test` で全10テストがパス
- [x] ブラウザで動作確認
- [x] 複数のTODOを追加して削除が正しく動作することを確認
- [x] 削除後も他のTODOが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)